### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/packages/cl/clerk.yaml
+++ b/packages/cl/clerk.yaml
@@ -320,7 +320,7 @@ description: |
 
   This project provides a dev environment via a `Nix` flake.
 
-  1. With [flakes enabled](https://nixos.wiki/wiki/Flakes#Enable_flakes), run:
+  1. With [flakes enabled](https://wiki.nixos.org/wiki/Flakes#Enable_flakes), run:
 
       ```console
       nix develop

--- a/packages/ha/haskell-language-server.yaml
+++ b/packages/ha/haskell-language-server.yaml
@@ -2455,7 +2455,7 @@ changelog: |
     - "Empty case split" code lens is added.
     - The name generator is fixed [to avoid dangerous summon rituals](https://github.com/haskell/haskell-language-server/pull/1760).
     - Many bugs related to type families and GADTs are fixed.
-  - We support [nix flake](https://nixos.wiki/wiki/Flakes), an upcoming way to manage dependencies in nix.
+  - We support [nix flake](https://wiki.nixos.org/wiki/Flakes), an upcoming way to manage dependencies in nix.
   - Every plugin (other than example plugins) now lives in its own package.
 
   ### Pull requests merged for 1.2.0

--- a/packages/ha/haskell-overridez.yaml
+++ b/packages/ha/haskell-overridez.yaml
@@ -38,7 +38,7 @@ description: ! "# haskell-overridez [![CircleCI](https://circleci.com/gh/adetoku
   Management](https://github.com/Gabriel439/haskell-nix/tree/master/project4) in [haskell-nix](https://github.com/Gabriel439/haskell-nix).\nThe
   idea is to turn the recommendations there into a tool that is itself installed into
   the nix environment.\n\n\n## Installation\n\nIt's assumed that you have already
-  [installed nix](https://nixos.wiki/wiki/Nix_Installation_Guide).\n\nYou can then
+  [installed nix](https://wiki.nixos.org/wiki/Nix_Installation_Guide).\n\nYou can then
   install `haskell-overridez` using `nix-env`:\n\n```bash\n\nnix-env --install -f
   https://github.com/adetokunbo/haskell-overridez/archive/v0.10.3.0.tar.gz\n\n```\n\n##
   Basic usage\n\nInstallation adds the executable `haskell-overridez` to the nix environment.\n\nIt

--- a/packages/im/imm.yaml
+++ b/packages/im/imm.yaml
@@ -232,7 +232,7 @@ description: |
   [1]: http://hackage.haskell.org/package/imm
   [2]: https://www.haskell.org
   [3]: https://dhall-lang.org/
-  [flakes]: https://nixos.wiki/wiki/Flakes
+  [flakes]: https://wiki.nixos.org/wiki/Flakes
 description-type: markdown
 hash: e59c0c342b14868552abe21d7edc2bf93f79b07b00c2d008cea97b01d6ca9096
 homepage: https://github.com/k0ral/imm

--- a/packages/ni/niv.yaml
+++ b/packages/ni/niv.yaml
@@ -85,7 +85,7 @@ description: "# niv\n\n[![Test](https://github.com/nmattia/niv/actions/workflows
   Getting started\n\nNix is a very powerful tool for building code and setting up
   environments. `niv` complements it by making it easy to describe and update remote
   dependencies (URLs, GitHub repos, etc). It is a simple, practical alternative to
-  [Nix flakes](https://nixos.wiki/wiki/Flakes).\n\nThis section covers common use
+  [Nix flakes](https://wiki.nixos.org/wiki/Flakes).\n\nThis section covers common use
   cases:\n\n* [Bootstrapping a Nix project](#bootstrapping-a-nix-project).\n* [Tracking
   a different nixpkgs branch](#tracking-a-nixpkgs-branch).\n* [Importing packages
   from GitHub](#importing-packages-from-github).\n* [Fetching packages from custom

--- a/packages/ta/tagtree.yaml
+++ b/packages/ta/tagtree.yaml
@@ -18,7 +18,7 @@ changelog-type: ''
 description: "# tagtree\n\nHaskell library for representing hierarchical tags, such
   as `foo/bar/qux`, as well as a tree of such tags and then searching them based on
   path patterns.\n\n## Developing\n\n- [Install Nix](https://nixos.org/download.html)
-  & [enable Flakes](https://nixos.wiki/wiki/Flakes)\n- Run `nix-shell --run haskell-language-server`
+  & [enable Flakes](https://wiki.nixos.org/wiki/Flakes)\n- Run `nix-shell --run haskell-language-server`
   to sanity check your environment \n- [Open as single-folder workspace](https://code.visualstudio.com/docs/editor/workspaces#_singlefolder-workspaces)
   in Visual Studio Code\n    - Install the [workspace recommended](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions)
   extensions\n    - <kbd>Ctrl+Shift+P</kbd> to run command \"Nix-Env: Select Environment\"

--- a/packages/ya/yarn2nix.yaml
+++ b/packages/ya/yarn2nix.yaml
@@ -147,7 +147,7 @@ description: |2
   it is possible to authenticate by overriding `fetchurl`
   to use the access credentials in `/etc/nix/netrc`.
 
-  Refer to the [Enterprise NixOS Wiki article](https://nixos.wiki/wiki/Enterprise)
+  Refer to the [Enterprise NixOS Wiki article](https://wiki.nixos.org/wiki/Enterprise)
   for instructions.
 
   ## Development


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️